### PR TITLE
Sdl version as a variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ share/
 licenses/
 .vscode/
 src/config.h
+src/sdl.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ add_executable(${EXEC_NAME} ${SOURCES})
 
 # Generate config.h from config.h.in
 configure_file(${CONFIG_DIR}/config.h.in ${INCLUDE_DIR}/config.h @ONLY)
+# Generate sdl.h from sdl.h.in
+configure_file(${CONFIG_DIR}/sdl.h.in ${INCLUDE_DIR}/sdl.h @ONLY)
 
 # Add definitions
 target_compile_definitions(${EXEC_NAME} PRIVATE 

--- a/cmake/PlatformDependencies.cmake
+++ b/cmake/PlatformDependencies.cmake
@@ -1,4 +1,7 @@
 
+# SDL version to link against
+set(SDL_USED_VERSION "SDL2")
+
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set(__SDL_PREFIX "/opt/sdl/windows")
     set(__ZLIB_PREFIX "/opt/zlib/windows")
@@ -6,7 +9,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     # From sdl2-config --libs
     # !PUT THESE BEFORE SDL2 LIBS!
     set(__SDL_EXTRA_LIBS "-lmingw32" "-mwindows")
-    set(__SDL_LIB_NAMES "SDL2main" "SDL2.dll" "SDL2_image.dll")
+    set(__SDL_LIB_NAMES "${SDL_USED_VERSION}main" "${SDL_USED_VERSION}.dll" "${SDL_USED_VERSION}_image.dll")
     # need static pthread for mingw-posix
     set(__OTHER_LIBS "-static" "winpthread")
     set(__ZLIB_LIB_NAMES "zlibstatic")
@@ -19,7 +22,7 @@ else()
     set(__SDL_PREFIX "/opt/sdl/unix")
     set(__ZLIB_PREFIX "/opt/zlib/unix")
     set(__LIBZIP_PREFIX "/opt/libzip/unix")
-    set(__SDL_LIB_NAMES "SDL2" "SDL2_image") 
+    set(__SDL_LIB_NAMES "${SDL_USED_VERSION}" "${SDL_USED_VERSION}_image") 
     set(__ZLIB_LIB_NAMES "libz.a")
     set(__LIBZIP_LIB_NAMES "zip")
     # From sdl2-config --cflags
@@ -70,6 +73,7 @@ set(DEPENDENCY_DEFINITIONS
 )
 
 # Exported variables:
+# SDL_USED_VERSION
 # SDL_LIB_DIR
 # SDL_BIN_DIR
 # DEPENDENCY_LIBS

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -1,6 +1,5 @@
 
-#ifndef CONFIG_H
-#define CONFIG_H
+#pragma once
 
 // Logs
 #define LOGS_DIR "@LOGS_DIR@"
@@ -13,5 +12,3 @@
 // Assets
 #define ASSETS_DIR "@ASSETS_DIR@"
 #define ASSETS_IMAGES_DIR "@ASSETS_IMAGES_DIR@"
-
-#endif

--- a/config/sdl.h.in
+++ b/config/sdl.h.in
@@ -11,7 +11,7 @@
 #include <@SDL_USED_VERSION@/SDL_timer.h>
 
 // for images (IMG_Load, etc)
-#include <SDL_image.h>
+#include <@SDL_USED_VERSION@/SDL_image.h>
 
 
 #endif 

--- a/config/sdl.h.in
+++ b/config/sdl.h.in
@@ -1,7 +1,6 @@
 // Contains SDL includes (depending on SDL version specified in cmake project)
 // Depends on variable SDL_USED_VERSION
-#ifndef SDL_INCLUDES_H
-#define SDL_INCLUDES_H
+#pragma once
 
 // for initializing and shutdown functions
 #include <@SDL_USED_VERSION@/SDL.h>
@@ -9,9 +8,3 @@
 #include <@SDL_USED_VERSION@/SDL_image.h>
 // for using SDL_Delay() functions
 #include <@SDL_USED_VERSION@/SDL_timer.h>
-
-// for images (IMG_Load, etc)
-#include <@SDL_USED_VERSION@/SDL_image.h>
-
-
-#endif 

--- a/config/sdl.h.in
+++ b/config/sdl.h.in
@@ -1,0 +1,17 @@
+// Contains SDL includes (depending on SDL version specified in cmake project)
+// Depends on variable SDL_USED_VERSION
+#ifndef SDL_INCLUDES_H
+#define SDL_INCLUDES_H
+
+// for initializing and shutdown functions
+#include <@SDL_USED_VERSION@/SDL.h>
+// for rendering images and graphics on screen
+#include <@SDL_USED_VERSION@/SDL_image.h>
+// for using SDL_Delay() functions
+#include <@SDL_USED_VERSION@/SDL_timer.h>
+
+// for images (IMG_Load, etc)
+#include <SDL_image.h>
+
+
+#endif 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,7 @@
 #include <iostream>
 #include <stdexcept>
-// for initializing and shutdown functions
-#include <SDL2/SDL.h>
-// for rendering images and graphics on screen
-#include <SDL2/SDL_image.h>
-// for using SDL_Delay() functions
-#include <SDL2/SDL_timer.h>
+
+#include "sdl.h"
 
 #include "config.h"
 


### PR DESCRIPTION
added variable SDL_USED_VERSION to PlatformDependencies.cmake
it's used now to determine sdl libs' names as well as include paths in generated sdl.h header